### PR TITLE
Add custom chat highlights

### DIFF
--- a/locales/irc4osu-en.json
+++ b/locales/irc4osu-en.json
@@ -44,5 +44,6 @@
 	"Attempting to join channel...": "Attempting to join channel...",
 	"Joined %s!": "Joined %s!",
 	"Created chat with %s!": "Created chat with %s!",
-	"Error joining": "Error joining"
+	"Error joining": "Error joining",
+	"Chat highlights (space separated)": "Chat highlights (space separated)"
 }

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -713,8 +713,22 @@ input[type=checkbox]:not(:checked) {
 	background-image: url("../images/switch_off.png");
 }
 
-#settings-modal input[type=checkbox] {
+#settings-modal input {
 	float: right;
+}
+
+#settings-modal input[type=text] {
+  font: 18px exo-main;
+  border-color: rgba(198, 18, 125, 1);
+  border-style: solid;
+  border-radius: 14px;
+  padding: 0 .5em 2px .5em;
+  margin: 6px 16px 6px 0;
+}
+
+#settings-modal input[type=text]:focus {
+  outline: none;
+  border-style: dashed;
 }
 
 #settings-modal label {

--- a/www/index.html
+++ b/www/index.html
@@ -138,6 +138,10 @@
           <label for="soundsCheckbox"><script>document.write(__("Notification sounds"));</script></label>
           <input type="checkbox" id="soundsCheckbox"/>
         </div>
+        <div class="row">
+          <label for="highlightsTextbox"><script>document.write(__("Chat highlights (space separated)"));</script></label>
+          <input type="text" id="highlightsTextbox"/>
+        </div>
       </div>
     </div>
     <div id="about-modal" style="display: none;" data-close="true" class="modal-container">

--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -236,6 +236,17 @@ $(document).on("change", "#soundsCheckbox", () => {
   });
 });
 
+// Highlights
+$(document).on("change", "#highlightsTextbox", () => {
+  client.getSettings(settings => {
+    settings.highlights = $("#highlightsTextbox").prop("value");
+    client.updateSettings(settings);
+
+    // Send settings to the main process
+    ipcRenderer.send("settings", settings);
+  });
+});
+
 // Whenever we use the mousewheel
 $(document).on("mousewheel", ".chat-container", e => {
 


### PR DESCRIPTION
Users can set custom chat highlights, so that they're able to be notified with terms/names that aren't their actual osu! username. Also, it checks case-insensitively now.

I'm not aware of any way to get a text-box setting on the taskbar menu, so that's not an included feature, unfortunately.